### PR TITLE
pigz: Update to 2.6

### DIFF
--- a/archivers/pigz/Portfile
+++ b/archivers/pigz/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pigz
-version             2.4
+version             2.6
 categories          archivers
 license             zlib Apache-2
 platforms           darwin
@@ -19,12 +19,10 @@ long_description    pigz, which stands for parallel implementation of gzip, \
 homepage            http://www.zlib.net/pigz/
 master_sites        ${homepage}
 
-checksums           rmd160  99ffd6ca6acbf29c436d80e814a144dfd1bd3337 \
-                    sha256  a4f816222a7b4269bd232680590b579ccc72591f1bb5adafcd7208ca77e14f73
+checksums           rmd160  42bd149f6a639d7db8517c23f3f0ccf6b0d7524a \
+                    sha256  2eed7b0d7449d1d70903f2a62cd6005d262eb3a8c9e98687bc8cbb5809db2a7d
 
 depends_lib         port:zlib
-
-patchfiles          patch-Makefile.diff
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

Update to version 2.6. No need for Makefile patch anymore (likely since https://github.com/madler/pigz/commit/c9de6c53dcf3eb1071c7999c8accc43ef2b3f458, but I did not verify).

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.5 20G71 arm64
Xcode 12.5.1 12E507

and

macOS 11.5 20G71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
